### PR TITLE
Fix import path for go-gopher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.15
 
 require (
 	github.com/gdamore/tcell/v2 v2.0.1-0.20201017141208-acf90d56d591
-	github.com/prologic/go-gopher v0.0.0-20210114215941-1859ade2470b
+	git.mills.io/prologic/go-gopher v0.0.0-20210114215941-1859ade2470b
 	github.com/rivo/tview v0.0.0-20210125085121-dbc1f32bb1d0
 )

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRR
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/prologic/go-gopher v0.0.0-20210114215941-1859ade2470b h1:bOYTIzro9GwU+OV5RJnFXCUW7fVnzY+wGDaL2ceFvn4=
-github.com/prologic/go-gopher v0.0.0-20210114215941-1859ade2470b/go.mod h1:ypKOIAVSaX4/TBkLcXhjcpSZKrBOmOd/sufqKUyM6Xc=
+git.mills.io/prologic/go-gopher v0.0.0-20210114215941-1859ade2470b h1:bOYTIzro9GwU+OV5RJnFXCUW7fVnzY+wGDaL2ceFvn4=
+git.mills.io/prologic/go-gopher v0.0.0-20210114215941-1859ade2470b/go.mod h1:ypKOIAVSaX4/TBkLcXhjcpSZKrBOmOd/sufqKUyM6Xc=
 github.com/rivo/tview v0.0.0-20210125085121-dbc1f32bb1d0 h1:WCfp+Jq9Mx156zIf9X6Frd6F19rf7wIRlm54UPxUfcU=
 github.com/rivo/tview v0.0.0-20210125085121-dbc1f32bb1d0/go.mod h1:1QW7hX7RQzOqyGgx8O64bRPQBrFtPflioPPX5gFPV3A=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/handlers.go
+++ b/handlers.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/prologic/go-gopher"
+	"git.mills.io/prologic/go-gopher"
 )
 
 var DEFAULT_DOWNLOAD_LOCAITON = fmt.Sprintf("%s/Downloads", os.Getenv("HOME"))

--- a/pageview.go
+++ b/pageview.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/gdamore/tcell/v2"
-	"github.com/prologic/go-gopher"
+	"git.mills.io/prologic/go-gopher"
 	"github.com/rivo/tview"
 )
 

--- a/types.go
+++ b/types.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/prologic/go-gopher"
+	"git.mills.io/prologic/go-gopher"
 )
 
 type ContentType int


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/go-gopher](https://git.mills.io/prologic/go-gopher).

For details on why see: https://github.com/prologic

Thank you! 🙇